### PR TITLE
Limit the number of comments to be displayed using queryString

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -30,6 +30,12 @@
       <version>2.8.6</version>
     </dependency>
 
+    <dependency>
+     <groupId>com.google.appengine</groupId>
+     <artifactId>appengine-api-1.0-sdk</artifactId>
+     <version>1.9.59</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -14,11 +14,19 @@
 
 package com.google.sps.servlets;
 
-import java.io.IOException;
-import javax.servlet.ServletException;
-import java.io.UnsupportedEncodingException;
+
 import com.google.gson.Gson;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.sql.Timestamp;
 import java.util.*; 
+import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -28,11 +36,34 @@ import java.nio.charset.StandardCharsets;
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
-
-  private List<String> comments = new ArrayList<String>();
-  
+  /*
+    Send at most commentsLimit comments back to the browser
+  */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
+    PreparedQuery results = datastore.prepare(query);
+   
+    int limit;
+    try {
+      limit = Integer.parseInt(getCommentsLimit(request));
+    } catch (Exception e)
+    {
+        // if data selected by user is invalid, use default value
+        limit = 5;
+    }
+
+    List<String> comments = new ArrayList<>();
+    for (Entity comment: results.asIterable()) {
+      comments.add((String)comment.getProperty("message"));
+
+      -- limit;
+      if (limit == 0) {
+        break;
+      }
+    }
+    
     Gson gson = new Gson();
     String commentsJson = gson.toJson(comments);
 
@@ -54,16 +85,40 @@ public class DataServlet extends HttpServlet {
       // Send a HTTP 500 error for other exceptions
       response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
     }
-    
-    comments.add(newComment);
+    Entity commentEntity = new Entity("Comment");
+    commentEntity.setProperty("message", newComment);
+
+    Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+    commentEntity.setProperty("timestamp", timestamp.getTime());
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    datastore.put(commentEntity);
 
     // Redirect back to the HTML page.
     response.sendRedirect("/index.html");
   }
+  /*
+    Get the maximum number of comments to be displayed from the queryString
+  */
+  private String getCommentsLimit(HttpServletRequest request) {
+    if (request.getQueryString() == null) {
+      return "5";
+    }
+    String[] queryStringArray = request.getQueryString().split("&");
+
+    for (String keyValuePair : queryStringArray) {
+      String[] keyValuePairArray = keyValuePair.split("=");
+      if (keyValuePairArray[0].equals("commentsLimit")) {
+        return keyValuePairArray[1];
+      }
+    }
+    // return default value if none was provided
+    return "5";
+  }
 
   private String getNewComment(HttpServletRequest request) throws UnsupportedEncodingException {
     String newComment = request.getParameter("new-comment");
-
+   
     byte[] commentBytes = newComment.getBytes("UTF-8");
     return newComment;
   }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -44,13 +44,13 @@ public class DataServlet extends HttpServlet {
     Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
     PreparedQuery results = datastore.prepare(query);
    
-    int limit;
+    Integer limit = null;
     try {
-      limit = Integer.parseInt(getCommentsLimit(request));
-    } catch (Exception e)
-    {
-        // if data selected by user is invalid, use default value
-        limit = 5;
+      // Get the maximum number of comments to be displayed from the queryString
+      limit = Integer.parseInt(request.getParameter("commentsLimit"));
+    } catch (Exception e) {
+      // Send a HTTP 400 Bad Request response if user provided invalid data.
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
     }
 
     List<String> comments = new ArrayList<>();
@@ -79,8 +79,7 @@ public class DataServlet extends HttpServlet {
     } catch (UnsupportedEncodingException e) {
       // Send a HTTP 400 Bad Request response if user provided invalid data.
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
-    } 
-    catch (Exception e) {
+    } catch (Exception e) {
       // Send a HTTP 500 error for other exceptions
       response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
     }
@@ -96,25 +95,7 @@ public class DataServlet extends HttpServlet {
     // Redirect back to the HTML page.
     response.sendRedirect("/index.html");
   }
-  /**
-   * Get the maximum number of comments to be displayed from the queryString
-   */
-  private String getCommentsLimit(HttpServletRequest request) {
-    if (request.getQueryString() == null) {
-      return "5";
-    }
-    String[] queryStringArray = request.getQueryString().split("&");
-
-    for (String keyValuePair : queryStringArray) {
-      String[] keyValuePairArray = keyValuePair.split("=");
-      if (keyValuePairArray[0].equals("commentsLimit")) {
-        return keyValuePairArray[1];
-      }
-    }
-    // return default value if none was provided
-    return "5";
-  }
-
+  
   private String getNewComment(HttpServletRequest request) throws UnsupportedEncodingException {
     String newComment = request.getParameter("new-comment");
    

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -14,7 +14,6 @@
 
 package com.google.sps.servlets;
 
-
 import com.google.gson.Gson;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -36,9 +35,9 @@ import java.nio.charset.StandardCharsets;
 /** Servlet that handles comments data */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
-  /*
-    Sends at most commentsLimit comments as a JSON string
-  */
+  /**
+   * Sends at most commentsLimit comments as a JSON string
+   */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
@@ -97,9 +96,9 @@ public class DataServlet extends HttpServlet {
     // Redirect back to the HTML page.
     response.sendRedirect("/index.html");
   }
-  /*
-    Get the maximum number of comments to be displayed from the queryString
-  */
+  /**
+   * Get the maximum number of comments to be displayed from the queryString
+   */
   private String getCommentsLimit(HttpServletRequest request) {
     if (request.getQueryString() == null) {
       return "5";

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -33,11 +33,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
 
-/** Servlet that returns some example content. TODO: modify this file to handle comments data */
+/** Servlet that handles comments data */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
   /*
-    Send at most commentsLimit comments back to the browser
+    Sends at most commentsLimit comments as a JSON string
   */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -1,0 +1,52 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.gson.Gson;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import java.io.IOException;
+import java.util.*; 
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+
+@WebServlet("/delete-data")
+public class DeleteDataServlet extends HttpServlet {
+  /*
+    Delete all the comments from datastore  
+  */
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Query query = new Query("Comment");
+    PreparedQuery results = datastore.prepare(query);
+
+    for (Entity comment: results.asIterable()) {
+      Key commentKey = comment.getKey();
+      datastore.delete(commentKey);
+    }
+
+    // Redirect back to the HTML page.
+    response.sendRedirect("/index.html");
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -45,8 +45,5 @@ public class DeleteDataServlet extends HttpServlet {
       Key commentKey = comment.getKey();
       datastore.delete(commentKey);
     }
-
-    // Redirect back to the HTML page.
-    response.sendRedirect("/index.html");
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -32,8 +32,8 @@ import java.nio.charset.StandardCharsets;
 
 @WebServlet("/delete-data")
 public class DeleteDataServlet extends HttpServlet {
-  /*
-    Delete all the comments from datastore  
+  /**
+   * Delete all the comments from datastore  
   */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -34,7 +34,7 @@ import java.nio.charset.StandardCharsets;
 public class DeleteDataServlet extends HttpServlet {
   /**
    * Delete all the comments from datastore  
-  */
+   */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="style.css">
     <script src="script.js"></script>
   </head>
-  <body onload="getComments()">
+  <body>
     <div id="content">
       <h1>AnaK's Portfolio</h1>
       
@@ -31,9 +31,12 @@
       <div id="random-image-container"></div>
 
       <p>Click <a href="placesGallery.html">here</a> to see some of my favourite places!</p>
-
+      
       <h1>Comments:</h1>
       <ul id="comments-history"></ul>
+
+      <p>Choose the maximum number of comments to be displayed:</p>
+      <input type="number" id="commentsLimit" name="commentsLimit" min="0" max="20" onchange="getComments()" >
       
       <form action="/data" method="POST">
       <p>Write a new comment:</p>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -34,9 +34,9 @@
       
       <h1>Comments:</h1>
       <ul id="comments-history"></ul>
-
+      
       <p>Choose the maximum number of comments to be displayed:</p>
-      <input type="number" id="commentsLimit" name="commentsLimit" min="0" max="20" onchange="getComments()" >
+      <input type="number" id="commentsLimit" name="commentsLimit" size="5" onchange="getComments()" >
       
       <form action="/data" method="POST">
       <p>Write a new comment:</p>
@@ -44,6 +44,8 @@
 
       <input type="submit" />
       </form>
+      
+      <button onclick="deleteAllComments()">Delete all the comments</button>
 
     </div>
   </body>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -36,7 +36,7 @@
       <ul id="comments-history"></ul>
       
       <p>Choose the maximum number of comments to be displayed:</p>
-      <input type="number" id="commentsLimit" name="commentsLimit" size="5" onchange="getComments()" >
+      <input type="number" id="commentsLimit" name="commentsLimit" min="0" max = "100" onchange="getComments()" >
       
       <form action="/data" method="POST">
       <p>Write a new comment:</p>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -58,11 +58,13 @@ function getRandomName() {
 }
 
 /**
- * Fetches comments from DataServlet and adds them to the DOM as a list.
+ * Fetches the last commentsLimit comments from DataServlet and adds them to the DOM as a list.
+   commentsLimit is selected by the user and sent to the server as parameter in the query string.
  */
 function getComments() {
-  fetch('/data').then(response => response.json()).then((comments) => {
+  const dataURL = `data?commentsLimit=${document.getElementById('commentsLimit').value}`;
 
+  fetch(dataURL).then(response => response.json()).then((comments) => {
     const commentsListElement = document.getElementById('comments-history');
     
     commentsListElement.innerHTML = '';

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -59,7 +59,7 @@ function getRandomName() {
 
 /**
  * Fetches the last commentsLimit comments from DataServlet and adds them to the DOM as a list.
-   commentsLimit is selected by the user and sent to the server as parameter in the query string.
+ * commentsLimit is selected by the user and sent to the server as parameter in the query string.
  */
 function getComments() {
   const dataURL = `data?commentsLimit=${document.getElementById('commentsLimit').value}`;

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -75,17 +75,17 @@ function getComments() {
   });
 }
 
-/*
-  Sends a POST request to DeleteDataServlet to delete all the comments and calls getComments() to
-  remove the comments from the page
-*/
+/** 
+ * Sends a POST request to DeleteDataServlet to delete all the comments and calls getComments() to
+ * remove the comments from the page
+ */
 function deleteAllComments() {
   fetch('delete-data', {method: 'POST'}).then(getComments());
 }
 
-/*
-  Returns HTML list element with text 
-*/
+/** 
+ * Returns HTML list element with text 
+ */
 function createListElement(text) {
   const liElement = document.createElement('li');
   liElement.innerText = text;

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -74,6 +74,15 @@ function getComments() {
     }
   });
 }
+
+/*
+  Sends a POST request to DeleteDataServlet to delete all the comments and calls getComments() to
+  remove the comments from the page
+*/
+function deleteAllComments() {
+  fetch('delete-data', {method: 'POST'}).then(getComments());
+}
+
 /*
   Returns HTML list element with text 
 */

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -62,17 +62,29 @@ function getRandomName() {
  * commentsLimit is selected by the user and sent to the server as parameter in the query string.
  */
 function getComments() {
-  const dataURL = `data?commentsLimit=${document.getElementById('commentsLimit').value}`;
+  const dataURL = `/data?commentsLimit=${document.getElementById('commentsLimit').value}`;
 
-  fetch(dataURL).then(response => response.json()).then((comments) => {
-    const commentsListElement = document.getElementById('comments-history');
+  fetch(dataURL).then(response => {
+      if (response.status == 200) {
+        return response.json();
+      } else {
+        if (response.status == 400) {
+          throw new Error("Invalid data: The number of comments should be between 0 and 100");
+        } else {
+          throw new Error("Error!");
+        }
+      }
+      }).then(comments => {
+      const commentsListElement = document.getElementById('comments-history');
     
-    commentsListElement.innerHTML = '';
-    for (const commentIndex in comments) {
-      commentsListElement.appendChild(
+      commentsListElement.innerHTML = '';
+      for (const commentIndex in comments) {
+        commentsListElement.appendChild(
           createListElement(comments[commentIndex]));
-    }
-  });
+      }
+      }).catch(dataError => {
+      alert(dataError);
+    });
 }
 
 /** 


### PR DESCRIPTION
_Store the comments posted on main page using Datastore:_
In DataServlet, when a comment is posted, doPost() will create a "Comment" entity with the comment message as a property. 

_Limit the number of comments to be displayed_:
When the value of commentsLimit is changed, getComments() in script.js will make a GET request with commentsLimit as a parameter in the query string;
In DataServlet, doGet() will load "Comment" entities from the datastore and send back a JSON string containing comments 
