### PR TITLE
Add feature that given a meeting information, returns the times when the meeting could happen that day

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
@@ -93,4 +93,16 @@ public final class Event {
     // interface documentation, equals will check for set-equality across all set implementations.
     return a.title.equals(b.title) && a.when.equals(b.when) && a.attendees.equals(b.attendees);
   }
+
+  /**
+   * Returns true iff at leas one attendee in requestedAttendees participates in this Event 
+   */
+  public boolean containsRequestedAttendees(Collection<String> requestedAttendees) {
+    for (String requestedAttendee : requestedAttendees) {
+      if (attendees.contains(requestedAttendee)) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
@@ -17,7 +17,9 @@ package com.google.sps;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.*;
 
 /**
  * Event is the container class for when a specific group of people are meeting and are therefore
@@ -98,10 +100,12 @@ public final class Event {
    * Returns true iff at leas one attendee in requestedAttendees participates in this Event 
    */
   public boolean containsRequestedAttendees(Collection<String> requestedAttendees) {
-    for (String requestedAttendee : requestedAttendees) {
-      if (attendees.contains(requestedAttendee)) {
-        return true;
-      }
+    Optional result = 
+    requestedAttendees.parallelStream()
+                      .filter(requestedAttendee -> attendees.contains(requestedAttendee) == true)
+                      .findAny();
+    if (result.isPresent()) {
+      return true;
     }
     return false;
   }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
@@ -19,7 +19,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.*;
+import java.util.stream.Collectors;
 
 /**
  * Event is the container class for when a specific group of people are meeting and are therefore
@@ -96,8 +96,7 @@ public final class Event {
     return a.title.equals(b.title) && a.when.equals(b.when) && a.attendees.equals(b.attendees);
   }
 
-  /**
-   * Returns true iff at leas one attendee in requestedAttendees participates in this Event 
+  /** Returns true iff at leas one attendee in requestedAttendees participates in this Event. 
    */
   public boolean containsRequestedAttendees(Collection<String> requestedAttendees) {
     Optional result = 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,17 +14,15 @@
 
 package com.google.sps;
 
-import java.io.*;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.ArrayList;
-import java.util.stream.*;
-
+import java.util.stream.Collectors;
 
 public final class FindMeetingQuery {
 
   /** Returns a Collection of time ranges when meeting {@code request} can be scheduled in the day of 
-    * events so that all attendees are free 
+    * events so that all attendees are free. 
     */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
 
@@ -59,9 +57,9 @@ public final class FindMeetingQuery {
   }
 
   /** In meetings array, add 1 to the start time of the meeting and substract 1 from the end time
-    * Only the endpoints are changed s.t. after all events are processed and the prefix sum is
+    * Only the endpoints are changed such that after all events are processed and the prefix sum is
     * computed, the number of meetings increases in the array starting from start time and ending
-    * right before the end time
+    * right before the end time.
    */
   private void updateNumberOfMeetings(ArrayList<Integer> meetings, TimeRange when) {
     // mark that a new meeting starts at when.start()
@@ -72,7 +70,9 @@ public final class FindMeetingQuery {
       meetings.set(when.end(), meetings.get(when.end()) - 1);
     }
   }
-
+  /** Computes prefix sum on meetings array such that meetings[x] will represent the number of
+    * meetings that happen at minute x.
+    */
   private void precomputePrefixSum(ArrayList<Integer> meetings) {
       // compute the sum starting from the second element because the prefix sum for the first 
       // element is the first element 
@@ -83,7 +83,7 @@ public final class FindMeetingQuery {
 
   /** Given meetings = an array where each element represents the number of meeting that occur at that
    * minute, and a duration, returns a Collection of time ranges in which the meeting lasting duration
-   * minutes can happen 
+   * minutes can happen. 
   */
   private Collection<TimeRange> findAvailableTimeRanges(ArrayList<Integer> meetings, int duration) {
     ArrayList<TimeRange> availableTimeRange = new ArrayList<TimeRange>();
@@ -99,7 +99,7 @@ public final class FindMeetingQuery {
         // there are no meetings during (lastUnavailableTime, endingTime]
         if (endingTime - lastUnavailableTime >= duration) {
           // add [lastUnavailableTime + 1, endingTime] as an available time range for the meeting
-          TimeRange timeRange = TimeRange.fromStartEnd(lastUnavailableTime + 1, endingTime, true);
+          TimeRange timeRange = TimeRange.fromStartEnd(lastUnavailableTime + 1, endingTime, /* inclusive = */ true);
           availableTimeRange.add(timeRange);
         }
       } 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -31,7 +31,7 @@ public final class FindMeetingQuery {
   }
 
   /** returns a Collection of time ranges when meeting {@code request} can be scheduled in the day of 
-    * {@code events} so that all attendees are free */
+    * events so that all attendees are free */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
 
     if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -22,53 +22,79 @@ import java.util.ArrayList;
 
 public final class FindMeetingQuery {
 
-  /** returns a Collection of time ranges when meeting {@code request} can be scheduled in the day of 
-    * events so that all attendees are free */
+  /** Returns a Collection of time ranges when meeting {@code request} can be scheduled in the day of 
+    * events so that all attendees are free 
+    */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    // array representing the number of meetings happening during that minute
-    ArrayList<Integer> meetings = new ArrayList<Integer>();
-    //before processing the events, the number of meetings for each minute is 0
-    meetings.addAll(Collections.nCopies(TimeRange.END_OF_DAY + 2, 0));
 
     if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
       // if the meeting lasts more than a day, there is no solution
       return new ArrayList<TimeRange>();
     }
 
+    // array that will represent the number of meetings happening during that minute
+    ArrayList<Integer> meetings = new ArrayList<Integer>();
+    // before processing the events, the number of meetings for each minute is 0
+    meetings.addAll(Collections.nCopies(TimeRange.END_OF_DAY - TimeRange.START_OF_DAY + 1, 0));
     Collection<String> attendees = request.getAttendees();
 
     for (Event event : events) {
       // at least one requested attendee is participating in the event
       if (event.containsRequestedAttendees(attendees)) {
-        // update the number of meetings during the time of event
+        // update the number of meetings for the start and end time of event
         updateNumberOfMeetings(meetings, event.getWhen());
       }
     }
+    // after all events are processed, for each minute x, meetings[x] will represent the number of
+    // meetings that start at minute x, minus the number of meetings that end right before minute x
+
+    // precompute the prefix sum on the meetings array s.t meetings[x] will represent the number of
+    // meetings that happen at minute x
+    precomputePrefixSum(meetings);
 
     return findAvailableTimeRanges(meetings, (int)request.getDuration());
   }
 
+  /** In meetings array, add 1 to the start time of the meeting and substract 1 from the end time
+    * Only the endpoints are changed s.t. after all events are processed and the prefix sum is
+    * computed, the number of meetings increases in the array starting from start time and ending
+    * right before the end time:
+    * (before computing the sum):  [ .... +1 ........ -1 .... ]
+    * (after computing the sum) :  [..... +1 +1 ... +1 0 .... ]
+   */
   private void updateNumberOfMeetings(ArrayList<Integer> meetings, TimeRange when) {
     // mark that a new meeting starts at when.start()
     meetings.set(when.start(), meetings.get(when.start()) + 1); 
     // mark that a new meeting ends right before when.end() 
-    meetings.set(when.end(), meetings.get(when.end()) - 1);
+    if (when.end() <= TimeRange.END_OF_DAY) {
+      // only update the end time of events that end before the day ends
+      meetings.set(when.end(), meetings.get(when.end()) - 1);
+    }
   }
 
-  /** returns a Collection of time ranges in which the meeting lasting duration minutes can happen */
+  private void precomputePrefixSum(ArrayList<Integer> meetings) {
+      // compute the sum starting from the second element because the prefix sum for the first 
+      // element is the first element 
+      for (int i = TimeRange.START_OF_DAY + 1; i <= TimeRange.END_OF_DAY; ++ i) {
+        meetings.set(i, meetings.get(i - 1) + meetings.get(i));
+      }
+  }
+
+  /** Given meetings = an array where each element represents the number of meeting that occur at that
+   * minute, and a duration, returns a Collection of time ranges in which the meeting lasting duration
+   * minutes can happen 
+  */
   private Collection<TimeRange> findAvailableTimeRanges(ArrayList<Integer> meetings, int duration) {
     ArrayList<TimeRange> availableTimeRange = new ArrayList<TimeRange>();
 
     int lastUnavailableTime = TimeRange.START_OF_DAY - 1;
     
     for (int endingTime = TimeRange.START_OF_DAY; endingTime <= TimeRange.END_OF_DAY; ++ endingTime) {
-      meetings.set(endingTime + 1, meetings.get(endingTime) + meetings.get(endingTime + 1));
-
       if (meetings.get(endingTime) != 0) {
         // at least one meeting is scheduled during minute endingTime
         lastUnavailableTime = endingTime;
       }
-      if (meetings.get(endingTime + 1) != 0 || endingTime == TimeRange.END_OF_DAY) {
+      if (endingTime == TimeRange.END_OF_DAY || meetings.get(endingTime + 1) != 0) {
         // there are no meetings during (lastUnavailableTime, endingTime]
         if (endingTime - lastUnavailableTime >= duration) {
           // add [lastUnavailableTime + 1, endingTime] as an available time range for the meeting

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -21,18 +21,14 @@ import java.util.ArrayList;
 
 
 public final class FindMeetingQuery {
-  // array representing the number of meetings happening during that minute
-  private ArrayList<Integer> meetings;
-
-  public FindMeetingQuery() {
-    meetings = new ArrayList<Integer>();
-    //before processing the events, the number of meetings for each minute is 0
-    meetings.addAll(Collections.nCopies(TimeRange.END_OF_DAY + 2, 0));
-  }
 
   /** returns a Collection of time ranges when meeting {@code request} can be scheduled in the day of 
     * events so that all attendees are free */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
+    // array representing the number of meetings happening during that minute
+    ArrayList<Integer> meetings = new ArrayList<Integer>();
+    //before processing the events, the number of meetings for each minute is 0
+    meetings.addAll(Collections.nCopies(TimeRange.END_OF_DAY + 2, 0));
 
     if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
       // if the meeting lasts more than a day, there is no solution
@@ -45,14 +41,14 @@ public final class FindMeetingQuery {
       // at least one requested attendee is participating in the event
       if (event.containsRequestedAttendees(attendees)) {
         // update the number of meetings during the time of event
-        updateNumberOfMeetings(event.getWhen());
+        updateNumberOfMeetings(meetings, event.getWhen());
       }
     }
 
-    return findAvailableTimeRanges((int)request.getDuration());
+    return findAvailableTimeRanges(meetings, (int)request.getDuration());
   }
 
-  private void updateNumberOfMeetings(TimeRange when) {
+  private void updateNumberOfMeetings(ArrayList<Integer> meetings, TimeRange when) {
     // mark that a new meeting starts at when.start()
     meetings.set(when.start(), meetings.get(when.start()) + 1); 
     // mark that a new meeting ends right before when.end() 
@@ -60,7 +56,7 @@ public final class FindMeetingQuery {
   }
 
   /** returns a Collection of time ranges in which the meeting lasting duration minutes can happen */
-  private Collection<TimeRange> findAvailableTimeRanges(int duration) {
+  private Collection<TimeRange> findAvailableTimeRanges(ArrayList<Integer> meetings, int duration) {
     ArrayList<TimeRange> availableTimeRange = new ArrayList<TimeRange>();
 
     int lastUnavailableTime = TimeRange.START_OF_DAY - 1;

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
@@ -20,11 +20,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 
-/** Class to represent a meeting request that has 
-  * 1. a name
-  * 2. a duration in minutes
-  * 3. a collection of attendees
-  */
 public final class MeetingRequest {
 
   /////////////////////////////////////////////

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
@@ -20,6 +20,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 
+/** Class to represent a meeting request that has 
+  * 1. a name
+  * 2. a duration in minutes
+  * 3. a collection of attendees
+  */
 public final class MeetingRequest {
 
   /////////////////////////////////////////////


### PR DESCRIPTION
Given a Collection of Event Objects and a MeetingRequest, the query() function in FindMeetingQuery.java will return a Collection of TimeRange Objects when the meeting could happen that day.

To schedule the meeting for the requested attendees, `attendees`, only meetings that contain at least one attendee that is present in `attendees` are counted. 
The meetings array is initialised in the constructor of FindMeetingQuery class.
`meetings.get(minute) `represents the number of meetings/events that are happening at minute `minute`
When a meeting is processed, `updateNumberOfMeetings(event.getWhen())` updates the number of meetings happening in the time range of `event.getWhen()`.

After all meetings are processed, `findAvailableTimeRanges` will check if the meeting could end at `endingTime` for all `endingTime` minutes in the day, .
To get the number of meetings that happen during each minute, the prefix sum is computed on the meetings array: `meetings.set(endingTime + 1, meetings.get(endingTime) + meetings.get(endingTime + 1));`

If there is at least one meeting at `endingTime`, the `lastUnavailabelTime` becomes `endingTime`,
If `[lastUnavailableTime + 1, endingTime]` can fit the meeting, and `[lastUnavailableTime + 1, endingTime + 1]` can't, then the time range is added to the solution.

Note: if time ranges `[a, b)` and `[b, c]` are suitable for the meeting, then only [a, c] is added to the solution
