### PR TITLE
Add support for optional attendees for a meeting

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
@@ -17,7 +17,9 @@ package com.google.sps;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.*;
 
 /**
  * Event is the container class for when a specific group of people are meeting and are therefore
@@ -97,10 +99,12 @@ public final class Event {
    * Returns true iff at leas one attendee in requestedAttendees participates in this Event 
    */
   public boolean containsRequestedAttendees(Collection<String> requestedAttendees) {
-    for (String requestedAttendee : requestedAttendees) {
-      if (attendees.contains(requestedAttendee)) {
-        return true;
-      }
+    Optional result = 
+    requestedAttendees.parallelStream()
+                      .filter(requestedAttendee -> attendees.contains(requestedAttendee) == true)
+                      .findAny();
+    if (result.isPresent()) {
+      return true;
     }
     return false;
   }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
@@ -93,4 +93,15 @@ public final class Event {
     // interface documentation, equals will check for set-equality across all set implementations.
     return a.title.equals(b.title) && a.when.equals(b.when) && a.attendees.equals(b.attendees);
   }
+  /**
+   * Returns true iff at leas one attendee in requestedAttendees participates in this Event 
+   */
+  public boolean containsRequestedAttendees(Collection<String> requestedAttendees) {
+    for (String requestedAttendee : requestedAttendees) {
+      if (attendees.contains(requestedAttendee)) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
@@ -95,17 +95,15 @@ public final class Event {
     // interface documentation, equals will check for set-equality across all set implementations.
     return a.title.equals(b.title) && a.when.equals(b.when) && a.attendees.equals(b.attendees);
   }
+  
   /**
    * Returns true iff at leas one attendee in requestedAttendees participates in this Event 
    */
   public boolean containsRequestedAttendees(Collection<String> requestedAttendees) {
-    Optional result = 
-    requestedAttendees.parallelStream()
+     
+    return requestedAttendees.parallelStream()
                       .filter(requestedAttendee -> attendees.contains(requestedAttendee) == true)
-                      .findAny();
-    if (result.isPresent()) {
-      return true;
-    }
-    return false;
+                      .findAny()
+                      .isPresent();
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -18,6 +18,7 @@ import java.io.*;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.ArrayList;
+import java.util.stream.*;
 
 
 public final class FindMeetingQuery {
@@ -49,56 +50,57 @@ public final class FindMeetingQuery {
     * events so that all attendees are free 
     */
   public Collection<TimeRange> queryWithoutOptionalAttendees(Collection<Event> events, MeetingRequest request) {
-
-    if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
+      if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
       // if the meeting lasts more than a day, there is no solution
       return new ArrayList<TimeRange>();
     }
 
     // array that will represent the number of meetings happening during that minute
     ArrayList<Integer> meetings = new ArrayList<Integer>();
-    //before processing the events, the number of meetings for each minute is 0
-    meetings.addAll(Collections.nCopies(TimeRange.END_OF_DAY + 1, 0));
+    // before processing the events, the number of meetings for each minute is 0
+    meetings.addAll(Collections.nCopies(TimeRange.END_OF_DAY - TimeRange.START_OF_DAY + 1, 0));
     Collection<String> attendees = request.getAttendees();
 
-    for (Event event : events) {
-      // at least one requested attendee is participating in the event
-      if (event.containsRequestedAttendees(attendees)) {
-        // update the number of meetings for the start and end time of event
-        updateNumberOfMeetings(meetings, event.getWhen());
-      }
-    }
+    // If at least one requested attendee is participating in the event
+    // update the number of meetings for the start and end time of event
+    events.parallelStream().filter(event -> (event.containsRequestedAttendees(attendees) == true))
+                            .map(Event::getWhen)
+                            .collect(Collectors.toList())
+                            .forEach(eventWhen -> updateNumberOfMeetings(meetings, eventWhen));
+
     // after all events are processed, for each minute x, meetings[x] will represent the number of
     // meetings that start at minute x, minus the number of meetings that end right before minute x
-    
 
     // precompute the prefix sum on the meetings array s.t meetings[x] will represent the number of
-    // meetings that happen at minute x
+    // meetings that happen at minute x:
+    // (before computing the sum):  [ .... +1 ........ -1 .... ]
+    // (after computing the sum) :  [..... +1 +1 ... +1 0 .... ]
     precomputePrefixSum(meetings);
 
     return findAvailableTimeRanges(meetings, (int)request.getDuration());
   }
 
   /** In meetings array, add 1 to the start time of the meeting and substract 1 from the end time
-    * Only the endpoints are changed s.t after all events are processed and the prefix sum is
+    * Only the endpoints are changed s.t. after all events are processed and the prefix sum is
     * computed, the number of meetings increases in the array starting from start time and ending
-    * right before the end time:
-    * (before computing the sum) meetings = [ .... +1 ........ -1 .... ]
-    * (after computing the sum)  meetings = [..... +1 +1 ... +1 0 .... ]
+    * right before the end time
    */
   private void updateNumberOfMeetings(ArrayList<Integer> meetings, TimeRange when) {
     // mark that a new meeting starts at when.start()
     meetings.set(when.start(), meetings.get(when.start()) + 1); 
     // mark that a new meeting ends right before when.end() 
-    meetings.set(when.end(), meetings.get(when.end()) - 1);
+    if (when.end() <= TimeRange.END_OF_DAY) {
+      // only update the end time of events that end before the day ends
+      meetings.set(when.end(), meetings.get(when.end()) - 1);
+    }
   }
 
   private void precomputePrefixSum(ArrayList<Integer> meetings) {
-      // compute the sum starting from the second element because the prefix sum for the first 
-      // element is the first element 
-      for (int i = TimeRange.START_OF_DAY + 1; i <= TimeRange.END_OF_DAY + 1; ++ i) {
-        meetings.set(i, meetings.get(i - 1) + meetings.get(i));
-      }
+    // compute the sum starting from the second element because the prefix sum for the first 
+    // element is the first element 
+    for (int i = TimeRange.START_OF_DAY + 1; i <= TimeRange.END_OF_DAY; ++ i) {
+      meetings.set(i, meetings.get(i - 1) + meetings.get(i));
+    }
   }
 
   /** Given meetings = an array where each element represents the number of meeting that occur at that

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,10 +14,86 @@
 
 package com.google.sps;
 
+import java.io.*;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.ArrayList;
+
 
 public final class FindMeetingQuery {
-  public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+  // array representing the number of meetings happening during that minute
+  private ArrayList<Integer> meetings;
+
+  public FindMeetingQuery() {
+    meetings = new ArrayList<Integer>();
+    //before processing the events, the number of meetings for each minute is 0
+    meetings.addAll(Collections.nCopies(TimeRange.END_OF_DAY + 2, 0));
+  }
+
+  public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request, Collection<String> optionalAttendees) {
+    Collection<String> allAttendees = request.getAttendees();
+    allAttendees.addAll(optionalAttendees);
+
+    MeetingRequest newRequest = new MeetingRequest(allAttendees, request.getDuration());
+    Collection<TimeRange> result = queryNoOptionalAttendees(events, newRequest);
+    if (result.size() > 0) {
+      return result;
+    }
+    return queryNoOptionalAttendees(events, request);
+  }
+
+  /** returns a Collection of time ranges when meeting {@code request} can be scheduled in the day of 
+    * events so that all attendees are free */
+  public Collection<TimeRange> queryNoOptionalAttendees(Collection<Event> events, MeetingRequest request) {
+
+    if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
+      // if the meeting lasts more than a day, there is no solution
+      return new ArrayList<TimeRange>();
+    }
+
+    Collection<String> attendees = request.getAttendees();
+
+    for (Event event : events) {
+      // at least one requested attendee is participating in the event
+      if (event.containsRequestedAttendees(attendees)) {
+        // update the number of meetings during the time of event
+        updateNumberOfMeetings(event.getWhen());
+      }
+    }
+
+    return findAvailableTimeRanges((int)request.getDuration());
+  }
+
+  private void updateNumberOfMeetings(TimeRange when) {
+    // mark that a new meeting starts at when.start()
+    meetings.set(when.start(), meetings.get(when.start()) + 1); 
+    // mark that a new meeting ends right before when.end() 
+    meetings.set(when.end(), meetings.get(when.end()) - 1);
+  }
+
+  /** returns a Collection of time ranges in which the meeting lasting duration minutes can happen */
+  private Collection<TimeRange> findAvailableTimeRanges(int duration) {
+    ArrayList<TimeRange> availableTimeRange = new ArrayList<TimeRange>();
+
+    int lastUnavailableTime = TimeRange.START_OF_DAY - 1;
+    
+    for (int endingTime = TimeRange.START_OF_DAY; endingTime <= TimeRange.END_OF_DAY; ++ endingTime) {
+      meetings.set(endingTime + 1, meetings.get(endingTime) + meetings.get(endingTime + 1));
+
+      if (meetings.get(endingTime) != 0) {
+        // at least one meeting is scheduled during minute endingTime
+        lastUnavailableTime = endingTime;
+      }
+      if (meetings.get(endingTime + 1) != 0 || endingTime == TimeRange.END_OF_DAY) {
+        // there are no meetings during (lastUnavailableTime, endingTime]
+        if (endingTime - lastUnavailableTime >= duration) {
+          // add [lastUnavailableTime + 1, endingTime] as an available time range for the meeting
+          TimeRange timeRange = TimeRange.fromStartEnd(lastUnavailableTime + 1, endingTime, true);
+          availableTimeRange.add(timeRange);
+        }
+      } 
+    }
+
+    return availableTimeRange;
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -75,9 +75,8 @@ public final class FindMeetingQuery {
     // meetings that happen at minute x:
     // (before computing the sum):  [ .... +1 ........ -1 .... ]
     // (after computing the sum) :  [..... +1 +1 ... +1 0 .... ]
-    precomputePrefixSum(meetings);
 
-    return findAvailableTimeRanges(meetings, (int)request.getDuration());
+    return findAvailableTimeRanges(precomputePrefixSum(meetings), (int)request.getDuration());
   }
 
   /** In meetings array, add 1 to the start time of the meeting and substract 1 from the end time
@@ -94,13 +93,19 @@ public final class FindMeetingQuery {
       meetings.set(when.end(), meetings.get(when.end()) - 1);
     }
   }
+  /** Given meetings array, returns meetingsSum, the prefix sum array such that meetingsSum[x] will
+    * represent the number of meetings that happen at minute x.
+    */
+  private ArrayList<Integer> precomputePrefixSum(ArrayList<Integer> meetings) { 
+    ArrayList<Integer> meetingsSum = new ArrayList<Integer>();
 
-  private void precomputePrefixSum(ArrayList<Integer> meetings) {
     // compute the sum starting from the second element because the prefix sum for the first 
-    // element is the first element 
+    // element is the first element
+    meetingsSum.add(meetings.get(0));
     for (int i = TimeRange.START_OF_DAY + 1; i <= TimeRange.END_OF_DAY; ++ i) {
-      meetings.set(i, meetings.get(i - 1) + meetings.get(i));
+      meetingsSum.add(meetingsSum.get(i - 1) + meetings.get(i));
     }
+    return meetingsSum;
   }
 
   /** Given meetings = an array where each element represents the number of meeting that occur at that

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/servlets/QueryServlet.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/servlets/QueryServlet.java
@@ -21,6 +21,7 @@ import com.google.sps.TimeRange;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -38,8 +39,9 @@ public class QueryServlet extends HttpServlet {
 
     // Find the possible meeting times.
     FindMeetingQuery findMeetingQuery = new FindMeetingQuery();
+    Collection<String> optionalAttendees = new ArrayList();
     Collection<TimeRange> answer =
-        findMeetingQuery.query(Arrays.asList(Events.events), meetingRequest);
+        findMeetingQuery.query(Arrays.asList(Events.events), meetingRequest, optionalAttendees);
 
     // Convert the times to JSON
     String jsonResponse = gson.toJson(answer);

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -14,7 +14,6 @@
 
 package com.google.sps;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -139,12 +138,13 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_A)),
         new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
             Arrays.asList(PERSON_B)),
-        new Event("Event 3", TimeRange.fromStartDuration(START_OF_DAY, DURATION_1_HOUR * 24),
+        new Event("Event 3", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, DURATION_1_HOUR * 24),
             Arrays.asList(PERSON_C)));
 
     MeetingRequest request =
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
-    Arrays<String> optionalAttendees = Arrays.asList(PERSON_C);
+
+    Collection<String> optionalAttendees = Arrays.asList(PERSON_C);
     Collection<TimeRange> actual = query.query(events, request, optionalAttendees);
     Collection<TimeRange> expected =
         Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
@@ -173,8 +173,8 @@ public final class FindMeetingQueryTest {
 
     MeetingRequest request =
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
-    Arrays<String> optionalAttendees = Arrays.asList(PERSON_C);
-    Collection<TimeRange> actual = query.query(events, request, optionalAttendees);
+    
+    Collection<TimeRange> actual = query.query(events, request, Arrays.asList(PERSON_C));
     Collection<TimeRange> expected =
         Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
@@ -373,14 +373,14 @@ public final class FindMeetingQueryTest {
 
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM),
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, true),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM),
+        new Event("Event 2", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, false),
             Arrays.asList(PERSON_B)));
     MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_30_MINUTES);
-    String[] optionals = {PERSON_A, PERSON_B};
-    Collection<TimeRange> actual = query.query(events, request, Arrays.asList(optionals));
-    Collection<TimeRange> expected = Arrays.asList(fromStartEnd(TIME_0900AM, END_OF_DAY, true));
+    
+    Collection<TimeRange> actual = query.query(events, request, Arrays.asList(PERSON_A, PERSON_B));
+    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -397,9 +397,7 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_B)));
     MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_30_MINUTES);
     
-    String[] optionals = {PERSON_A, PERSON_B};
-    
-    Collection<TimeRange> actual = query.query(events, request, Arrays.asList(optionals));
+    Collection<TimeRange> actual = query.query(events, request, Arrays.asList(PERSON_A, PERSON_B));
     Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
 
     Assert.assertEquals(expected, actual);

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,6 +34,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -43,6 +44,7 @@ public final class FindMeetingQueryTest {
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
 
+  private static final int DURATION_15_MINUTES = 15;
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;
@@ -60,7 +62,7 @@ public final class FindMeetingQueryTest {
   public void optionsForNoAttendees() {
     MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_1_HOUR);
 
-    Collection<TimeRange> actual = query.query(NO_EVENTS, request);
+    Collection<TimeRange> actual = query.query(NO_EVENTS, request, NO_ATTENDEES);
     Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
 
     Assert.assertEquals(expected, actual);
@@ -72,7 +74,7 @@ public final class FindMeetingQueryTest {
     int duration = TimeRange.WHOLE_DAY.duration() + 1;
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), duration);
 
-    Collection<TimeRange> actual = query.query(NO_EVENTS, request);
+    Collection<TimeRange> actual = query.query(NO_EVENTS, request, NO_ATTENDEES);
     Collection<TimeRange> expected = Arrays.asList();
 
     Assert.assertEquals(expected, actual);
@@ -86,7 +88,7 @@ public final class FindMeetingQueryTest {
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
-    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> actual = query.query(events, request, NO_ATTENDEES);
     Collection<TimeRange> expected =
         Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true));
@@ -96,7 +98,7 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void everyAttendeeIsConsidered() {
-    // Have each person have different events. We should see two options because each person has
+    // Have each person have different events. We should see three options because each person has
     // split the restricted times.
     //
     // Events  :       |--A--|     |--B--|
@@ -112,10 +114,69 @@ public final class FindMeetingQueryTest {
     MeetingRequest request =
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
-    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> actual = query.query(events, request, NO_ATTENDEES);
     Collection<TimeRange> expected =
         Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void everyAttendeeIsConsideredAndBusyOptional() {
+    // Have each mandatory person have different events and add optional person C who is busy all day 
+    // We should see three options because each mandatory person has split the restricted times.
+    // 
+    //
+    // Events  :       |--A--|     |--B--|
+    //           |-------------C--------------|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(START_OF_DAY, DURATION_1_HOUR * 24),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    Arrays<String> optionalAttendees = Arrays.asList(PERSON_C);
+    Collection<TimeRange> actual = query.query(events, request, optionalAttendees);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void everyAttendeeIsConsideredPlusOptional() {
+    // Have each mandatory person have different events and add optional person C who has an event
+    // between 8:30 and 9:00. We should see two options 
+    //
+    // Events  :       |--A--|--C--|--B--|-----|
+    // Day     : |-----------------------------|
+    // Options : |--1--|                 |--2--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    Arrays<String> optionalAttendees = Arrays.asList(PERSON_C);
+    Collection<TimeRange> actual = query.query(events, request, optionalAttendees);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
@@ -139,7 +200,7 @@ public final class FindMeetingQueryTest {
     MeetingRequest request =
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
-    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> actual = query.query(events, request, NO_ATTENDEES);
     Collection<TimeRange> expected =
         Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
@@ -166,7 +227,7 @@ public final class FindMeetingQueryTest {
     MeetingRequest request =
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
-    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> actual = query.query(events, request, NO_ATTENDEES);
     Collection<TimeRange> expected =
         Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
@@ -191,7 +252,7 @@ public final class FindMeetingQueryTest {
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
-    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> actual = query.query(events, request, NO_ATTENDEES);
     Collection<TimeRange> expected =
         Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
@@ -216,7 +277,34 @@ public final class FindMeetingQueryTest {
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
-    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> actual = query.query(events, request, NO_ATTENDEES);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void justEnoughRoomAndOptionalAttendee() {
+    // Based on justEnoughRoom, add an optional attendee B who has an event between 8:30 and 8:45.
+    // The optional attendee should be ignored since considering their schedule would result in a
+    // time slot smaller than the requested time.
+    //
+    // Events  : |--A--|-B-|   |----A----|
+    // Day     : |-----------------------|
+    // Options :       |-------|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_15_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request, Arrays.asList(PERSON_B));
     Collection<TimeRange> expected =
         Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
 
@@ -231,7 +319,7 @@ public final class FindMeetingQueryTest {
         TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_B), DURATION_30_MINUTES);
 
-    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> actual = query.query(events, request, NO_ATTENDEES);
     Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
 
     Assert.assertEquals(expected, actual);
@@ -242,7 +330,7 @@ public final class FindMeetingQueryTest {
     MeetingRequest request =
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
-    Collection<TimeRange> actual = query.query(NO_EVENTS, request);
+    Collection<TimeRange> actual = query.query(NO_EVENTS, request, NO_ATTENDEES);
     Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
 
     Assert.assertEquals(expected, actual);
@@ -252,6 +340,7 @@ public final class FindMeetingQueryTest {
   public void notEnoughRoom() {
     // Have one person, but make it so that there is not enough room at any point in the day to
     // have the meeting.
+    //
     //
     // Events  : |--A-----| |-----A----|
     // Day     : |---------------------|
@@ -265,10 +354,56 @@ public final class FindMeetingQueryTest {
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
 
-    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> actual = query.query(events, request, NO_ATTENDEES);
     Collection<TimeRange> expected = Arrays.asList();
 
     Assert.assertEquals(expected, actual);
   }
+
+  @Test
+  public void noMandatoryAttendees() {
+    // No mandatory attendees, just two optional attendees with several gaps in their schedules.
+    // Those gaps should be identified and returned.
+    //
+    //
+    // Events  : |--A-----|
+    //           |--B--------|
+    // Day     : |---------------------|
+    // Options :             |---------|
+
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM),
+            Arrays.asList(PERSON_B)));
+    MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_30_MINUTES);
+    String[] optionals = {PERSON_A, PERSON_B};
+    Collection<TimeRange> actual = query.query(events, request, Arrays.asList(optionals));
+    Collection<TimeRange> expected = Arrays.asList(fromStartEnd(TIME_0900AM, END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void noMandatoryAttendeesAndBusyOptionalAttendees() {
+    // No mandatory attendees, just two optional attendees with no gaps in their schedules.
+    // query should return that the whole day is available since the optional attendees cannot 
+    // be accommodated and the mandatory ones (all zero of them) are free all day.
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, DURATION_1_HOUR * 24),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, DURATION_1_HOUR * 24),
+            Arrays.asList(PERSON_B)));
+    MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_30_MINUTES);
+    
+    String[] optionals = {PERSON_A, PERSON_B};
+    
+    Collection<TimeRange> actual = query.query(events, request, Arrays.asList(optionals));
+    Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
+
+    Assert.assertEquals(expected, actual);
+  }
 }
+
 

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -125,7 +125,8 @@ public final class FindMeetingQueryTest {
   @Test
   public void everyAttendeeIsConsideredAndBusyOptional() {
     // Have each mandatory person have different events and add optional person C who is busy all day 
-    // We should see three options because each mandatory person has split the restricted times.
+    // We should see three options because the optional attendee is ignored and each mandatory person
+    // has split the restricted times.
     // 
     //
     // Events  :       |--A--|     |--B--|
@@ -159,7 +160,7 @@ public final class FindMeetingQueryTest {
     // Have each mandatory person have different events and add optional person C who has an event
     // between 8:30 and 9:00. We should see two options 
     //
-    // Events  :       |--A--|--C--|--B--|-----|
+    // Events  :       |--A--|--C--|--B--|
     // Day     : |-----------------------------|
     // Options : |--1--|                 |--2--|
 
@@ -287,7 +288,7 @@ public final class FindMeetingQueryTest {
   @Test
   public void justEnoughRoomAndOptionalAttendee() {
     // Based on justEnoughRoom, add an optional attendee B who has an event between 8:30 and 8:45.
-    // The optional attendee should be ignored since considering their schedule would result in a
+    // The optional attendee should be ignored since considering B's schedule would result in a
     // time slot smaller than the requested time.
     //
     // Events  : |--A--|-B-|   |----A----|
@@ -362,8 +363,8 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void noMandatoryAttendees() {
-    // No mandatory attendees, just two optional attendees with several gaps in their schedules.
-    // Those gaps should be identified and returned.
+    // No mandatory attendees, just two optional attendees with one gap in their schedules.
+    // The gap should be identified and returned.
     //
     //
     // Events  : |--A-----|
@@ -403,5 +404,3 @@ public final class FindMeetingQueryTest {
     Assert.assertEquals(expected, actual);
   }
 }
-
-


### PR DESCRIPTION
Add functionality of optional attendees:
If one or more time slots exists s.t. both mandatory and optional attendees can attend, the query function returns those time slots. 
Otherwise, it returns the time slots that fit just the mandatory attendees.

Add `Collection<String> optionalAttendees` parameter to the query function in current branch in FindMeetingQuery.java
Rename the `query` function from branch **meetingAlgorithm** to `queryWithoutOptionalAttendees`

First, the `query` function searches the time slots for a new `MeetingRequest` object that considers both optional and mandatory attendees as mandatory:
`result = queryWithoutOptionalAttendees(events, newRequest);`
If `result` is empty, `query` will return the time slots that fit just the mandatory attendees:
`queryWithoutOptionalAttendees(events, request);`

Note: this branch will be merged after **meetingAlgorithm** is merged